### PR TITLE
layer_cake_ct.qos: improve filter parameters

### DIFF
--- a/usr/lib/sqm/layer_cake_ct.qos
+++ b/usr/lib/sqm/layer_cake_ct.qos
@@ -41,8 +41,8 @@ ingress() {
 
     # redirect all IP packets arriving in $IFACE to ifb0
     # set DSCP mark from conntrack mark
-    $TC filter add dev $IFACE parent ffff: protocol all prio 10 u32 \
-    match u32 0 0 flowid 1:1 action ctinfo dscp 0x0000003f mirred egress redirect dev $DEV
+    $TC filter add dev $IFACE parent ffff: matchall \
+    action ctinfo dscp 0x0000003f mirred egress redirect dev $DEV
 }
 
 sqm_prepare_script() {


### PR DESCRIPTION
Use 'matchall' filter type to match all packets instead of u32 matching
on everything.

Remove flowid 1:1 as this can make cake 'flow blind'

https://lists.bufferbloat.net/pipermail/cake/2019-September/005031.html

Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>